### PR TITLE
Problem node identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,20 +55,20 @@ print(worker.StandardizationReport)
     {
       "test": "SomaChildrenFurcation",
       "description": "Children nodes of the soma should not branch. The returned node IDs are immediate children of the soma that branch.",
-      "nodes_with_error": [(2, 313, 4409, 8981)]
+      "nodes_with_error": [(2, 313.0, 4409.0, 8981.0)]
     },
     {
       "test": "AxonOrigins",
       "description": "Axon should originate from a single location and should stem from axon, soma, or basal dendrite. Invalid axon origins are returned.",
       "nodes_with_error": [
-        (58, 3231, 3131, 9218), (423, 3521, 3320, 7840), (424, 3104, 3344, 8889),
+        (58, 3231.0, 3131.0, 9218.0), (423, 3521.0, 3320.0, 7840.0), (424, 3104.0, 3344.0, 8889.0),
       ]
     },
     {
       "test": "DendriteOrigins",
       "description": "Each apical/basal dendritic node should have a parent node with type 1 (soma) or its respective dendrite type.",
       "nodes_with_error": [
-        (3, 310, 1310, 3044, 7742) , (15,530, 5502, 8173)
+        (3, 310, 1310.0, 3044.0, 7742.0) , (15,530.0, 5502.0, 8173.0)
       ]
     }
   ],

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ worker.validate()
 worker.write_to_swc(output_swc_path="QCd_File.swc")
 
 # Generate an HTML report for the single cell
-worker.report_to_html(report_path="Cell_QC_Report.html")
+# where node_display_mode='both' will write node ID and x,y,z coordinates
+worker.report_to_html(report_path="Cell_QC_Report.html", node_display_mode='both')
 
 # Can inspect the report
 # This may be useful for writing the QC records to a database
@@ -54,24 +55,20 @@ print(worker.StandardizationReport)
     {
       "test": "SomaChildrenFurcation",
       "description": "Children nodes of the soma should not branch. The returned node IDs are immediate children of the soma that branch.",
-      "node_ids_with_error": [2]
+      "nodes_with_error": [(2, 313, 4409, 8981)]
     },
     {
       "test": "AxonOrigins",
       "description": "Axon should originate from a single location and should stem from axon, soma, or basal dendrite. Invalid axon origins are returned.",
-      "node_ids_with_error": [
-        58, 423, 424, 2153, 2189, 2192, 2193, 2510, 2512, 2773, 2778, 2783, 
-        5162, 5176, 5181, 5184, 5186, 5208, 5227, 5229, 5231, 5258, 5260, 
-        5283, 5285
+      "nodes_with_error": [
+        (58, 3231, 3131, 9218), (423, 3521, 3320, 7840), (424, 3104, 3344, 8889),
       ]
     },
     {
       "test": "DendriteOrigins",
       "description": "Each apical/basal dendritic node should have a parent node with type 1 (soma) or its respective dendrite type.",
-      "node_ids_with_error": [
-        3, 15, 16, 40, 56, 86, 88, 119, 139, 190, 221, 223, 230, 233, 261, 
-        4269, 4272, 4283, 4286, 4292, 4302, 4304, 4338, 4349, 4356, 4358, 
-        4360, 4361, 4367
+      "nodes_with_error": [
+        (3, 310, 1310, 3044, 7742) , (15,530, 5502, 8173)
       ]
     }
   ],
@@ -94,9 +91,9 @@ for swc_path in [path_to_swc_1, path_to_swc_2]:
     this_report = worker.StandardizationReport
     all_reports.append(this_report)
     
-# Generate a combined HTML report for multiple cells
-create_html_report(data=all_reports, report_path="MultiCellReport.html")
-``````
+# Generate a combined HTML report for multiple cells, display just the x,y,z coordinate
+create_html_report(data=all_reports, report_path="MultiCellReport.html", node_display_mode='coord')
+```
 
 
 ## Example 3: Standardizing a Single SWC File + Soma MIP QC. UNTESTED
@@ -126,5 +123,5 @@ worker = Standardizer(
 worker.validate()
 
 # Generate an HTML report for the single cell
-worker.report_to_html(report_path="Single_Cell_QC_Report_With_Soma_MIP.html")
+worker.report_to_html(report_path="Single_Cell_QC_Report_With_Soma_MIP.html", node_display_mode='coord')
 ```

--- a/standard_morph/Standardizer.py
+++ b/standard_morph/Standardizer.py
@@ -290,6 +290,8 @@ def create_html_report(data: list, report_path: str, node_display_mode='id') -> 
         elif node_display_mode == 'both':
             return f"{node[0]}: ({node[1]}, {node[2]}, {node[3]})"
         else:
+            warn = f"invalid node_display_mode passed, expected ['id','coord','both']. Got: {node_display_mode}"
+            warnings.warn(warn, UserWarning)
             return str(node[0])
 
     html_content = """

--- a/standard_morph/Standardizer.py
+++ b/standard_morph/Standardizer.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from collections import defaultdict
 from typing import Optional
 from enum import Enum
+import warnings
 
 from standard_morph.tools import (
     soma_and_soma_children_qc,
@@ -57,6 +58,7 @@ class Standardizer:
         swc_separator: str = ' ',
         valid_filename_format: FilenameFormat = FilenameFormat.NONE,
         soma_mip_kwargs: dict = None,
+        allow_soma_children_to_branch: bool = False,
     ):
         """
         Class for running SWC standardization.
@@ -68,6 +70,7 @@ class Standardizer:
             swc_separator (str): Column separator in SWC file.
             valid_filename_format (FilenameFormat): Filename format validation option.
             soma_mip_kwargs (dict): Keyword arguments for get_soma_mip function.
+            allow_soma_children_to_branch (bool): when True, immediate children of soma are allowed to branch 
         """
         self.path_to_swc = path_to_swc
         self.input_morphology_df = input_morphology_df
@@ -75,6 +78,7 @@ class Standardizer:
         self.valid_filename_format = valid_filename_format
         self.soma_mip_kwargs = soma_mip_kwargs or {}
         self.soma_children_distance_threshold = soma_children_distance_threshold
+        self.allow_soma_children_to_branch = allow_soma_children_to_branch
         
         self._validate_inputs()
         self.load_data()
@@ -86,7 +90,6 @@ class Standardizer:
             "StandardMorphVersion": get_version(),
             "path_to_mip": None,
         }
-        print(self.morph_df)
 
     def _validate_inputs(self):
         """Validate the inputs."""
@@ -160,12 +163,12 @@ class Standardizer:
     def _append_if_error(self, report_list):
         """Append QC report if it contains errors."""
         for report in report_list:
-            if report.get('node_ids_with_error') is not None:
+            if report.get('nodes_with_error') is not None:
                 self.StandardizationReport['errors'].append(report)
 
     def validate(self):
         """Run validation checks and build the report."""
-        self._append_if_error(soma_and_soma_children_qc(self.morph_df, self.soma_children_distance_threshold))
+        self._append_if_error(soma_and_soma_children_qc(self.morph_df, self.allow_soma_children_to_branch, self.soma_children_distance_threshold))
         self._append_if_error(axon_origination_qc(self.morph_df))
         self._append_if_error(dendrite_origins_qc(self.morph_df))
         self._append_if_error(orphan_node_check(self.morph_df))
@@ -207,30 +210,38 @@ class Standardizer:
                                     index=False, 
                                     header=None, 
                                     mode="a" )
-        
-        
-        
-    def report_to_html(self, report_path):
+          
+    def report_to_html(self, report_path, node_display_mode='id'):
         """
         Generate an HTML report for a single neuron based on `self.StandardizationReport`.
 
         report_path: path to report html file
+        node_display_mode: 'id', 'coord', or 'both' to show node ID, coordinates, or both in error list
         """
         report = self.StandardizationReport
-
-        # Extract details
-        neuron_name = os.path.basename(report["input_file"])  # Get filename as neuron name
-
+        neuron_name = os.path.basename(report["input_file"])
         path_to_mip = report.get("path_to_mip", None)
-
-        # Handle errors
         errors = report.get("errors", [])
+
+        def format_node(node):
+            if node_display_mode == 'id':
+                return str(node[0])
+            elif node_display_mode == 'coord':
+                return f"({node[1]}, {node[2]}, {node[3]})"
+            elif node_display_mode == 'both':
+                return f"{node[0]}: ({node[1]}, {node[2]}, {node[3]})"
+            else:
+                warn = f"invalid node_display_mode passed, expected ['id','coord','both']. Got: {node_display_mode}"
+                warnings.warn(warn, UserWarning)
+                return str(node[0])
+
         if errors:
             error_details = "<ul>"
             for error in errors:
                 error_details += f"<li><b>{error['test']}:</b> {error['description']}"
-                if error["node_ids_with_error"]:
-                    error_details += f" (Nodes: {', '.join(map(str, error['node_ids_with_error']))})"
+                if error["nodes_with_error"]:
+                    formatted_nodes = ', '.join(format_node(n) for n in error["nodes_with_error"])
+                    error_details += f" (Nodes: {formatted_nodes})"
                 error_details += "</li>"
             error_details += "</ul>"
             error_class = "error"
@@ -238,154 +249,88 @@ class Standardizer:
             error_details = "<span class='no-error'>No errors found</span>"
             error_class = "no-error"
 
-        # HTML content
         html_content = f"""
-        <!DOCTYPE html>
-        <html lang="en">
+        <html>
         <head>
-            <meta charset="UTF-8">
-            <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <title>{neuron_name} - QC Report</title>
+            <title>Standardization Report: {neuron_name}</title>
             <style>
-                body {{
-                    font-family: Arial, sans-serif;
-                    font-size: 18px;
-                }}
-                table {{
-                    width: 100%;
-                    border-collapse: collapse;
-                    font-size: 18px;
-                }}
-                table, th, td {{
-                    border: 1px solid black;
-                }}
-                th, td {{
-                    padding: 5px;
-                    text-align: left;
-                }}
-                th {{
-                    background-color: #f2f2f2;
-                }}
-                img {{
-                    max-width: 256px;
-                    height: auto;
-                }}
-                .error {{
-                    color: red;
-                    font-weight: bold;
-                }}
-                .no-error {{
-                    color: green;
-                    font-weight: bold;
-                }}
+                body {{ font-family: Arial, sans-serif; margin: 40px; }}
+                h1 {{ color: #333; }}
+                .error {{ color: red; }}
+                .no-error {{ color: green; }}
+                img {{ max-width: 800px; display: block; margin-top: 20px; }}
             </style>
         </head>
         <body>
-            <h1>QC Report for {neuron_name}</h1>
-            <table>
-                <tr>
-                    <th>Neuron</th>
-                    <th>QC Errors</th>
-                    <th>Soma MIP</th>
-                    <th>StandardMorph Version</th>
-                </tr>
-                <tr>
-                    <td><b>{neuron_name}</b></td>
-                    <td class="{error_class}">{error_details}</td>
-                    <td>{f'<img src="{path_to_mip}" alt="Soma MIP">' if path_to_mip else "No Image Available"}</td>
-                    <td>{report.get("StandardMorphVersion", "Unknown")}</td>
-                </tr>
-            </table>
+            <h1>Standardization Report: {neuron_name}</h1>
+            <p><strong>StandardMorph Version:</strong> {report.get("StandardMorphVersion", "Unknown")}</p>
+            <p class="{error_class}"><strong>Errors:</strong><br>{error_details}</p>
+            {'<img src="' + path_to_mip + '" alt="MIP Image">' if path_to_mip else ''}
         </body>
         </html>
         """
 
-        # Save report
         with open(report_path, 'w') as f:
             f.write(html_content)
 
         print(f"Report saved to {report_path}")
-        
 
-def create_html_report(data: list, report_path: str) -> None:
-    """
-    Create an HTML report from the QC validation data. This is used when you have a list of 
-    reports that you want to write to an html. Standardizer.report_to_html should be used for
-    the case of writing a single cell report to an html.
 
-    Parameters
-    ----------
-    data : list
-        A list of dictionaries, each representing a Standardizer.StandardizationReport
-    report_path : str
-        The path to save the html report.
+def create_html_report(data: list, report_path: str, node_display_mode='id') -> None:
     """
+    Create an HTML report from a list of StandardizationReports.
+
+    node_display_mode: 'id', 'coord', or 'both' to control display of nodes_with_error
+    """
+    def format_node(node):
+        if node_display_mode == 'id':
+            return str(node[0])
+        elif node_display_mode == 'coord':
+            return f"({node[1]}, {node[2]}, {node[3]})"
+        elif node_display_mode == 'both':
+            return f"{node[0]}: ({node[1]}, {node[2]}, {node[3]})"
+        else:
+            return str(node[0])
 
     html_content = """
-    <!DOCTYPE html>
-    <html lang="en">
+    <html>
     <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>SWC QC Report</title>
+        <title>Standardization Report Summary</title>
         <style>
-            body {
-                font-family: Arial, sans-serif;
-                font-size: 18px;
-            }
-            table {
-                width: 100%;
-                border-collapse: collapse;
-                font-size: 18px;
-            }
-            table, th, td {
-                border: 1px solid black;
-            }
-            th, td {
-                padding: 5px;
-                text-align: left;
-            }
-            th {
-                background-color: #f2f2f2;
-            }
-            img {
-                max-width: 128px;
-                height: auto;
-            }
-            .error {
-                color: red;
-                font-weight: bold;
-            }
-            .no-error {
-                color: green;
-                font-weight: bold;
-            }
+            body { font-family: Arial, sans-serif; margin: 40px; }
+            h1 { color: #333; }
+            table { border-collapse: collapse; width: 100%; }
+            th, td { border: 1px solid #ccc; padding: 8px; text-align: left; }
+            th { background-color: #f2f2f2; }
+            .error { color: red; }
+            .no-error { color: green; }
+            img { max-width: 200px; display: block; }
         </style>
     </head>
     <body>
-        <h1>SWC QC Report</h1>
+        <h1>Standardization Report Summary</h1>
         <table>
             <tr>
-                <th>Neuron</th>
-                <th>QC Errors</th>
-                <th>Soma MIP</th>
+                <th>Neuron Name</th>
                 <th>StandardMorph Version</th>
+                <th>Errors</th>
+                <th>MIP Image</th>
             </tr>
     """
 
     for neuron_data in data:
-        neuron_name = os.path.basename(neuron_data["input_file"])  # Extract filename as neuron name
+        neuron_name = os.path.basename(neuron_data["input_file"])
         path_to_mip = neuron_data.get("path_to_mip", None)
-        standard_morph_version = neuron_data.get("StandardMorphVersion", "Unknown")
-        
-        # Handle errors
+        version = neuron_data.get("StandardMorphVersion", "Unknown")
         errors = neuron_data.get("errors", [])
+
         if errors:
             error_details = "<ul>"
             for error in errors:
                 error_details += f"<li><b>{error['test']}:</b> {error['description']}"
-                if error["node_ids_with_error"]:
-                    error_details += f" (Nodes: {', '.join(map(str, error['node_ids_with_error']))})"
+                if error["nodes_with_error"]:
+                    formatted_nodes = ', '.join(format_node(n) for n in error["nodes_with_error"])
+                    error_details += f" (Nodes: {formatted_nodes})"
                 error_details += "</li>"
             error_details += "</ul>"
             error_class = "error"
@@ -393,14 +338,15 @@ def create_html_report(data: list, report_path: str) -> None:
             error_details = "<span class='no-error'>No errors found</span>"
             error_class = "no-error"
 
-        # Append the row for this neuron
+        mip_img_tag = f'<img src="{path_to_mip}" alt="MIP Image">' if path_to_mip else "N/A"
+
         html_content += f"""
-        <tr>
-            <td><b>{neuron_name}</b></td>
-            <td class="{error_class}">{error_details}</td>
-            <td>{f'<img src="{path_to_mip}" alt="Soma MIP">' if path_to_mip else "No Image Available"}</td>
-            <td>{standard_morph_version}</td>
-        </tr>
+            <tr>
+                <td>{neuron_name}</td>
+                <td>{version}</td>
+                <td class="{error_class}">{error_details}</td>
+                <td>{mip_img_tag}</td>
+            </tr>
         """
 
     html_content += """

--- a/tests/test_axon_origination.py
+++ b/tests/test_axon_origination.py
@@ -20,7 +20,7 @@ class TestAxonOriginationQC(unittest.TestCase):
     def test_valid_axon_origination(self):
         """Test case where axon originates correctly from soma or basal dendrite."""
         result = axon_origination_qc(self.sample_data)[0]
-        self.assertIsNone(result['node_ids_with_error'], "Axon origination should be valid.")
+        self.assertIsNone(result['nodes_with_error'], "Axon origination should be valid.")
 
     def test_invalid_multiple_axon_origins(self):
         """Test case where axon originates from multiple locations."""
@@ -36,8 +36,8 @@ class TestAxonOriginationQC(unittest.TestCase):
         df = pd.DataFrame(data) #.set_index('node_id')
         result = axon_origination_qc(df)[0]
         
-        self.assertIsNotNone(result['node_ids_with_error'], "Should detect multiple axon origins.")
-        self.assertGreater(len(result['node_ids_with_error']), 1, "More than one invalid axon origin should be found.")
+        self.assertIsNotNone(result['nodes_with_error'], "Should detect multiple axon origins.")
+        self.assertGreater(len(result['nodes_with_error']), 1, "More than one invalid axon origin should be found.")
 
     def test_invalid_axon_origin_type(self):
         """Test case where axon originates from an invalid compartment."""
@@ -53,8 +53,8 @@ class TestAxonOriginationQC(unittest.TestCase):
         df = pd.DataFrame(data) #.set_index('node_id')
         result = axon_origination_qc(df)[0]
         
-        self.assertIsNotNone(result['node_ids_with_error'], "Should detect invalid axon origin type.")
-        self.assertEqual(result['node_ids_with_error'], [3], "Only node 3 should be flagged as an invalid origin.")
+        self.assertIsNotNone(result['nodes_with_error'], "Should detect invalid axon origin type.")
+        self.assertEqual(result['nodes_with_error'], [(3,10,10,10)], "Only node 3 should be flagged as an invalid origin.")
 
 
 if __name__ == '__main__':

--- a/tests/test_cycles.py
+++ b/tests/test_cycles.py
@@ -11,11 +11,11 @@ class TestCheckCyclesAndTopologicalSort(unittest.TestCase):
         """Set up dummy dataframes and child dictionaries for testing."""
         # Valid acyclic graph with multiple DFS possibilities
         self.df_valid = pd.DataFrame([
-            {"node_id": 3, "parent": -1},  
-            {"node_id": 2, "parent": 3},
-            {"node_id": 1, "parent": 3},
-            {"node_id": 4, "parent": 1},
-            {"node_id": 5, "parent": 2},
+            {"node_id": 3, "parent": -1, "x": 0, "y": 0, "z": 0},  
+            {"node_id": 2, "parent": 3,  "x": 1, "y": 1, "z": 1},
+            {"node_id": 1, "parent": 3,  "x": 2, "y": 2, "z": 2},
+            {"node_id": 4, "parent": 1,  "x": 3, "y": 3, "z": 3},
+            {"node_id": 5, "parent": 2,  "x": 4, "y": 4, "z": 4},
         ])
         self.child_dict_valid = defaultdict(list, {
             3: [2, 1],  # The order in which 2 and 1 are visited can vary
@@ -32,12 +32,12 @@ class TestCheckCyclesAndTopologicalSort(unittest.TestCase):
         
         # Graph with a cycle (invalid)
         self.df_cyclic = pd.DataFrame([
-            {"node_id": 1, "parent": -1},  # Root
-            {"node_id": 2, "parent": 1},
-            {"node_id": 3, "parent": 2},
-            {"node_id": 4, "parent": 3},
-            {"node_id": 5, "parent": 4},
-            {"node_id": 2, "parent": 5},  # Cycle (node 2 pointing back)
+            {"node_id": 1, "parent": -1, "x": 0, "y": 0, "z": 0},  # Root
+            {"node_id": 2, "parent": 1,  "x": 1, "y": 1, "z": 1},
+            {"node_id": 3, "parent": 2,  "x": 2, "y": 2, "z": 2},
+            {"node_id": 4, "parent": 3,  "x": 3, "y": 3, "z": 3},
+            {"node_id": 5, "parent": 4,  "x": 4, "y": 4, "z": 4},
+            {"node_id": 2, "parent": 5,  "x": 1, "y": 1, "z": 1},  # Cycle (node 2 pointing back)
         ])
         self.child_dict_cyclic = defaultdict(list, {
             1: [2],
@@ -51,7 +51,7 @@ class TestCheckCyclesAndTopologicalSort(unittest.TestCase):
         """Test that a valid acyclic graph returns a correct DFS-based topological sorting."""
         cycle_report, node_mapping = check_cycles_and_topological_sort(self.df_valid, self.child_dict_valid)
         cycle_report = cycle_report[0]
-        self.assertEqual(cycle_report['node_ids_with_error'], None,  "Expected no cycles in the valid graph.")
+        self.assertEqual(cycle_report['nodes_with_error'], None,  "Expected no cycles in the valid graph.")
         self.assertEqual(set(node_mapping.keys()), set(self.df_valid["node_id"]), "Node IDs should match.")
         self.assertEqual(len(node_mapping), len(self.df_valid), "All nodes should be assigned a new label.")
 
@@ -64,7 +64,7 @@ class TestCheckCyclesAndTopologicalSort(unittest.TestCase):
         """Test that a cyclic graph is detected correctly."""
         cycle_report, node_mapping = check_cycles_and_topological_sort(self.df_cyclic, self.child_dict_cyclic)
         cycle_report = cycle_report[0]
-        self.assertEqual(cycle_report['node_ids_with_error'], [1], "Expected a cycle to be detected.")
+        self.assertEqual(cycle_report['nodes_with_error'], [(1,0,0,0)], "Expected a cycle to be detected.")
         self.assertEqual(node_mapping, {}, "Expected an empty mapping when a cycle is detected.")
 
 

--- a/tests/test_for_orphaned_nodes.py
+++ b/tests/test_for_orphaned_nodes.py
@@ -7,12 +7,12 @@ class TestOrphanNodeCheck(unittest.TestCase):
     def setUp(self):
         """Set up a dummy neuron morphology DataFrame."""
         data = [
-            {"node_id": 1, "compartment": 1, "parent": -1, "parent_node_type": None},  # Root (soma)
-            {"node_id": 2, "compartment": 3, "parent": 1, "parent_node_type": 1},  # Valid child
-            {"node_id": 3, "compartment": 3, "parent": 1, "parent_node_type": 1},  # Valid child
-            {"node_id": 4, "compartment": 3, "parent": 2, "parent_node_type": 3},  # Valid branch
-            {"node_id": 5, "compartment": 3, "parent": 10, "parent_node_type": None},  # Orphaned (invalid parent)
-            {"node_id": 6, "compartment": 3, "parent": 20, "parent_node_type": None},  # Orphaned (missing parent type)
+            {"node_id": 1, "compartment": 1, "parent": -1, "parent_node_type": None, "x": 1, "y": 1, "z": 1},  # Root (soma)
+            {"node_id": 2, "compartment": 3, "parent": 1,  "parent_node_type": 1,    "x": 2, "y": 2, "z": 2},  # Valid child
+            {"node_id": 3, "compartment": 3, "parent": 1,  "parent_node_type": 1,    "x": 3, "y": 3, "z": 3},  # Valid child
+            {"node_id": 4, "compartment": 3, "parent": 2,  "parent_node_type": 3,    "x": 4, "y": 4, "z": 4},  # Valid branch
+            {"node_id": 5, "compartment": 3, "parent": 10, "parent_node_type": None, "x": 5, "y": 5, "z": 5},  # Orphaned
+            {"node_id": 6, "compartment": 3, "parent": 20, "parent_node_type": None, "x": 6, "y": 6, "z": 6},  # Orphaned
         ]
 
         self.df = pd.DataFrame(data).set_index("node_id")
@@ -22,15 +22,15 @@ class TestOrphanNodeCheck(unittest.TestCase):
         """Test case where orphan nodes exist."""
         result = orphan_node_check(self.df)[0]
         print(result)
-        self.assertIsNotNone(result["node_ids_with_error"], "Expected orphan nodes but none were detected.")
-        self.assertIn(5, result["node_ids_with_error"], "Node 5 should be detected as an orphan.")
-        self.assertIn(6, result["node_ids_with_error"], "Node 6 should be detected as an orphan.")
+        self.assertIsNotNone(result["nodes_with_error"], "Expected orphan nodes but none were detected.")
+        self.assertIn((5,5,5,5), result["nodes_with_error"], "Node 5 should be detected as an orphan.")
+        self.assertIn( (6,6,6,6), result["nodes_with_error"], "Node 6 should be detected as an orphan.")
 
     def test_no_orphan_nodes(self):
         """Test case where all nodes have valid parents."""
         df_valid = self.df.copy().drop([5, 6]) 
         result = orphan_node_check(df_valid)[0]
-        self.assertIsNone(result["node_ids_with_error"], "Expected no orphan nodes.")
+        self.assertIsNone(result["nodes_with_error"], "Expected no orphan nodes.")
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_soma_and_soma_children.py
+++ b/tests/test_soma_and_soma_children.py
@@ -36,28 +36,28 @@ class TestSomaQC(unittest.TestCase):
         """Test that a valid SWC structure does not trigger errors."""
         errors = soma_and_soma_children_qc(self.valid_swc)
         for error in errors:
-            self.assertIsNone(error["node_ids_with_error"])
+            self.assertIsNone(error["nodes_with_error"])
 
     def test_multiple_somas(self):
         """Test that multiple soma nodes are correctly detected."""
         errors = soma_and_soma_children_qc(self.multiple_somas)
         soma_error = next(err for err in errors if err["test"] == "NumberOfSomas")
-        self.assertIsNotNone(soma_error["node_ids_with_error"])
-        self.assertSetEqual(set(soma_error["node_ids_with_error"]), {1, 2})
+        self.assertIsNotNone(soma_error["nodes_with_error"])
+        self.assertEqual(soma_error["nodes_with_error"], [(1,0,0,0), (2,0,0,0)] )
 
     def test_soma_children_branching(self):
         """Test that improperly branching soma children are detected."""
         errors = soma_and_soma_children_qc(self.soma_children_branching)
         branching_error = next(err for err in errors if err["test"] == "SomaChildrenFurcation")
-        self.assertIsNotNone(branching_error["node_ids_with_error"])
-        self.assertSetEqual(set(branching_error["node_ids_with_error"]), {2})
+        self.assertIsNotNone(branching_error["nodes_with_error"])
+        self.assertEqual(branching_error["nodes_with_error"], [(2, 10, 0, 0)])
 
     def test_soma_children_exceed_distance(self):
         """Test that soma children exceeding the distance threshold are detected."""
         errors = soma_and_soma_children_qc(self.soma_children_exceed_distance, soma_child_distance_threshold=50)
         distance_error = next(err for err in errors if err["test"] == "SomaChildrenDistance")
-        self.assertIsNotNone(distance_error["node_ids_with_error"])
-        self.assertSetEqual(set(distance_error["node_ids_with_error"]), {2})
+        self.assertIsNotNone(distance_error["nodes_with_error"])
+        self.assertEqual(distance_error["nodes_with_error"] , [(2, 60, 0, 0)] )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- StandardizationReport no longer has node_ids_with_error, has been updated to nodes_with_error 
- subsequently, the values of StandardizationReport ['nodes_with_error '] are list of tuples where the tuple is (node_id, coord_x, coord_y, coord_z) 
- option for what node data to display in the report html, can show node id, coord or both
- optional bool input for Standardizer (allow_soma_children_to_branch) where when set True, immediate children of the soma node are allowed to branch