### PR TITLE
Feat: update valid AIND filename formats

### DIFF
--- a/standard_morph/Standardizer.py
+++ b/standard_morph/Standardizer.py
@@ -167,7 +167,7 @@ class Standardizer:
         # Now read the SWC file as usual, ignoring the header lines (#)
         swc_df = pd.read_csv(
             self.path_to_swc,
-            delim_whitespace=True,
+            sep=r'\s+',
             comment="#",
             header=None,
             names=SWC_COLUMN_NAMES,

--- a/standard_morph/tools.py
+++ b/standard_morph/tools.py
@@ -324,7 +324,7 @@ def has_valid_name(swc_file: str, name_format='AIND'):
         'nodes_with_error' field.
     """
     if name_format == 'AIND':
-        pattern = r"^N\d{1,}[-_]\d{6}(?:[-_](?:[A-Za-z]{2,3}|consensus)|[-_](?:axon|dendrite)[-_][A-Za-z]{2,3})?\.swc$"
+        pattern = r"^N\d{1,}[-_]\d{6}(?:[-_](?:[A-Za-z]{2,3}|consensus)|[-_](?:axon|dendrite)[-_](?:[A-Za-z]{2,3}|consensus))?\.swc$"
 
     else:
         print("TODO: AIBS FILE NAME RE CHECK")

--- a/standard_morph/tools.py
+++ b/standard_morph/tools.py
@@ -324,7 +324,7 @@ def has_valid_name(swc_file: str, name_format='AIND'):
         'nodes_with_error' field.
     """
     if name_format == 'AIND':
-        pattern = r"^N\d{1,}(-|_)\d{6}(-|_)(axon|dendrite|dendrites)(-|_)([A-Za-z]{2,3}|consensus)\.swc$"
+        pattern = r"^N\d{1,}[-_]\d{6}(?:[-_](?:[A-Za-z]{2,3}|consensus)|[-_](?:axon|dendrite)[-_][A-Za-z]{2,3})?\.swc$"
 
     else:
         print("TODO: AIBS FILE NAME RE CHECK")

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,6 +1,7 @@
 import unittest
 import pandas as pd
 from standard_morph.Standardizer import Standardizer
+from standard_morph.tools import has_valid_name
 
 class TestStandardizer(unittest.TestCase):
 
@@ -111,6 +112,38 @@ class TestStandardizer(unittest.TestCase):
         """Test that missing filename format does not trigger errors."""
         standardizer = Standardizer(path_to_swc=None, input_morphology_df=self.valid_df, valid_filename_format=self.missing_filename_format)
         self.assertEqual(standardizer.valid_filename_format, self.missing_filename_format)
+
+class TestFilenameValidation(unittest.TestCase):
+
+    def test_aind_valid_filename_formats(self):
+        valid_filenames = [
+            "N024-648434.swc",
+            "N024-648434-PG.swc",
+            "N024-648434-LEH.swc",
+            "N003-706301-axon-AG.swc",
+            "N003-706301-dendrite-SC.swc",
+            "N102-123456-CONSENSUS.swc",
+        ]
+
+        for filename in valid_filenames:
+            with self.subTest(filename=filename):
+                result = has_valid_name(filename)[0]
+                self.assertIsNone(result["nodes_with_error"])
+
+    def test_aind_invalid_filename_formats(self):
+        invalid_filenames = [
+            "N003-706301-dendrites-SC.swc",
+            "024-648434.swc",
+            "N024-64843.swc",
+            "N003-706301-apical-AG.swc",
+            "N024-648434-PG.txt",
+        ]
+
+        for filename in invalid_filenames:
+            with self.subTest(filename=filename):
+                result = has_valid_name(filename)[0]
+                self.assertEqual(result["nodes_with_error"], [(1,0,0,0)])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -123,6 +123,8 @@ class TestFilenameValidation(unittest.TestCase):
             "N003-706301-axon-AG.swc",
             "N003-706301-dendrite-SC.swc",
             "N102-123456-CONSENSUS.swc",
+            "N041-653158-dendrite-CONSENSUS.swc",
+            "N041-653158-axon-CONSENSUS.swc",
         ]
 
         for filename in valid_filenames:
@@ -137,6 +139,7 @@ class TestFilenameValidation(unittest.TestCase):
             "N024-64843.swc",
             "N003-706301-apical-AG.swc",
             "N024-648434-PG.txt",
+            "N041-653158-CONSENSUS-axon-CONSENSUS.swc",
         ]
 
         for filename in invalid_filenames:


### PR DESCRIPTION
This PR updates the AIND filename check to support the following in-the-wild variants:

"N024-648434.swc" (final naming scheme in the portal)
"N024-648434-PG.swc" (name after merging axon and dendrite in the processing pipeline)
"N024-648434-LEH.swc" 
"N003-706301-axon-AG.swc" (Initial un-merged compartment tracings from Horta)
"N003-706301-dendrite-SC.swc"
"N102-123456-CONSENSUS.swc" (merged consensus tracing by multiple annotators)
"N041-653158-dendrite-CONSENSUS.swc" (individual compartment consensus tracing by multiple annotators)
"N041-653158-axon-CONSENSUS.swc"

It removes support for names containing "dendrites" (plural) since this is not supported in other codebases (e.g., aind-morphology-utils).