### PR TITLE
Feat: updates pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,16 +8,20 @@ version = "0.1.0"
 description = "Standardizing morphologies"
 readme = "README.md"
 authors = [{ name = "Matthew Mallory", email = "matt.mallory@alleninstitute.org" }]
-license = { text = "MIT" }
+requires-python = ">=3.9"
+license = "MIT"
 dependencies = [
+    "numpy",
     "pandas",
 ]
 
 [tool.setuptools.packages.find]
-where = ["."]  
+where = ["."]
+exclude = ["tests", "tests.*"]
 
 [project.optional-dependencies]
-SomaMip = ["imageio", "s3fs", "zarr", "scikit-image"] 
+soma-mip = ["imageio", "s3fs", "zarr", "scikit-image"]
+test = ["pytest"]
 
 [tool.setuptools.package-data]
 "standard_morph" = ["*"]


### PR DESCRIPTION
**Summary**

Updates `pyproject.toml` to make the package metadata and dependency declarations more accurate and reliable.

**Changes**

- Added `requires-python = ">=3.9"` so installers and `uv` do not infer an unintended Python range.
- Changed license metadata from the deprecated table form to the current SPDX string form:
  ```toml
  license = "MIT"
  ```
- Added `numpy` as a direct dependency because the package imports it directly.
- Excluded `tests` from package discovery so test modules are not installed as part of the wheel.
- Renamed the optional dependency extra from `SomaMip` to `soma-mip` to follow normalized extra naming conventions.
- Added a `test` extra with `pytest` so the test suite can be run through project metadata:
  ```bash
  uv run --extra test pytest
  ```